### PR TITLE
Fixing compilation issues with Typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
-import { ComponentType } from 'react';
-
 declare module 'react-native-dropdown-picker' {
+  import { ComponentType } from 'react';
+
+ 
   type DropDownPicker = {
     items: {label: any, value: any, icon?: () => JSX.Element, disabled?: boolean, selected?: boolean}[];
     defaultValue?: any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,5 @@
 declare module 'react-native-dropdown-picker' {
   import { ComponentType } from 'react';
-
  
   type DropDownPicker = {
     items: {label: any, value: any, icon?: () => JSX.Element, disabled?: boolean, selected?: boolean}[];


### PR DESCRIPTION
When attempting to compile with the current typescript definition file, I am getting errors like this:
```
node_modules/react-native-dropdown-picker/index.d.ts:42:5 - error TS2666: Exports and export assignments are not permitted in module augmentations.

42     export default DropDownPicker;
```

This error can be fixed by moving the imports into the declare module block.