### PR TITLE
Automatically scroll to defaultValue for first load

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ https://github.com/oblador/react-native-vector-icons
 - Added `labelLength` property.
 - Added `scrollViewProps` property.
 - Added `controller` property.
+- Added `autoScrollToDefaultValue` property.
 - Some bug-fixes.
 
 ## Getting Started
@@ -586,6 +587,7 @@ dropDownStyle={{marginTop: 2}}
 | `zIndex`                         | This property specifies the stack order of the component.                                                        | `number`                  | `5000`                         | No       |
 | `disabled`                       | Disables the component.                                                                                          | `bool`                    | `false`                        | No       |
 | `isVisible`                      | Open or close the dropdown box.                                                                                  | `bool`                    | `false`                        | No       |
+| `autoScrollToDefaultValue`       | If true, automatically scroll to `defaultValue`/first `defaultValue` (multiple) during first render of dropdown  | `bool`                    | `false`                        | No       |
 | `multiple`                       | If set to true selecting multiple items is possible.                                                             | `bool`                    | `false`                        | No       |
 | `multipleText`                   | a Text to inform the user how many items have been selected.                                                     | `string`                  | `%d items have been selected`  | No       |
 | `min`                            | Minimum number of items.                                                                                         | `number`                  | `0`                            | No       |

--- a/index.d.ts
+++ b/index.d.ts
@@ -26,6 +26,7 @@ declare module 'react-native-dropdown-picker' {
     zIndex?: number;
     disabled?: boolean;
     isVisible?: boolean;
+    autoScrollToDefaultValue?: boolean;
     multiple?: boolean;
     multipleText?: string;
     min?: number;


### PR DESCRIPTION
Hey there again! I messed up my previous pull request so I decided to make a new one with the updated changes 😆. 

I'm currently using this library as a dropdown menu for selection of date of birth.
With regards to the auto scroll issue posted not long ago, I've tried to implement this functionality in this pull request.

- Storing of y-coordinates of each dropdown element in the array.
- Triggering `ScrollView.ref.scrollTo` method only when the dropdown menu is first loaded (along with a short timeout of 200ms, where you will see the list scroll to your default value).
- `scrollTo` will scroll to the `defaultValue`/ first `defaultValue` (for multiple `defaultValues`).
- Added `autoScrollToDefaultValue` props to enable this automatic scrolling.

The issues faced were:
- ~~I wasn't able to find the exact lifecycle method to trigger the scrollTo method (I did put it in the componentDidMount method but since the dropdown is not rendered until a click is registered on the picker component itself, it is not able to store the y-coordinates of all the elements in the dropdown component.~~ I placed the `scrollTo` method in componentDidUpdate with a check if `state.initialScroll` and `state.isVisible` is true.
- ~~I needed to find a way to only trigger scrollTo for the first loading of the dropdown menu, since the ScrollView stays at the position of the value being selected.~~ This issue was solved along with the first issue as well.
- ~~I'm also not sure if we should implement auto scroll for multiple default values as well. ~~ I decided to just scroll to the first selected item, but do let me know if there is a concern still.

Thank you and I appreciate your reply in offering your help too. Please let me know if there are any concerns with regards to the code changes that I've made 😄.