### PR TITLE
fix: remove deprecated import of ViewProps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,7 @@ import {
     TouchableOpacity,
     ScrollView,
     Platform,
-    TextInput,
-    ViewPropTypes
+    TextInput
 } from 'react-native';
 
 // Icon


### PR DESCRIPTION
I am using this component with `react-native-web` and the `ViewPropTypes` has been deprecated

The import is not used so I guess just removing it should be ok:

References:
https://github.com/reactrondev/react-native-web-swiper/issues/41
https://github.com/necolas/react-native-web/issues/1537
Based on the author:
`Remove prop types exports from package. These are deprecated in React Native and introduce significant DEV time performance cost. Flow types are now preferred `
https://www.digitalocean.com/community/tutorials/react-the-new-proptypes#:~:text=As%20of%20React%20v15.,a%20package%20of%20their%20own.&text=The%20downside%20is%20that%20if,calling%20PropTypes%20directly%20since%20v15.