### PR TITLE
Check if defaultValue is undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ class DropDownPicker extends React.Component {
     static getDerivedStateFromProps(props, state) {
         // Change default value (! multiple)
         if (! state.props.multiple && props.defaultValue !== state.props.defaultValue) {
-            const { label, value, icon } = props.defaultValue === null ? {
+            const { label, value, icon } = props.defaultValue === null || props.defaultValue === undefined ? {
                 label: null,
                 value: null,
                 icon: () => {}


### PR DESCRIPTION
I noticed that the DropdownPicker will throw an "TypeError undefined is not an object (evaluating '_ref 3.label')" if the `defaultValue` ever becomes `undefined` while `items` is still defined.
This is fixed if the `defaultValue` is set to `null` instead, but this is far from intuitive. `undefined` and `null` have the same meaning here.
I was considering negating the property instead of explicitly checking. But that would fail if any users have a list with an empty string or 0.

I found a similar check at line 371:

```
const isPlaceholderActive = this.state.choice.label === null || (Array.isArray(this.state.choice) && this.state.choice.length === 0);
```

But I'm not entirely sure what effect it would have to make the same change there so I'm leaving it. 