### PR TITLE
Fix Cannot read property 'globalTextStyle' of undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -568,7 +568,7 @@ class DropDownPicker extends React.Component {
                             this.renderItem(item, index, items.length)
                         ) : (
                             <View style={styles.notFound}>
-                                {this.props.searchableError(this.style.globalTextStyle)}
+                                {this.props.searchableError(this.props.style.globalTextStyle)}
                             </View>
                         )}
                     </ScrollView>


### PR DESCRIPTION
I noticed that it was trying to get `style` from the component itself instead of from `this.props`, so fixed it.