### PR TITLE
Export instance type from controller property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare module "react-native-dropdown-picker" {
     TextInputProps,
   } from "react-native";
 
-  type ItemType = {
+  export type ItemType = {
     label: any;
     value: any;
     icon?: () => JSX.Element;
@@ -19,8 +19,26 @@ declare module "react-native-dropdown-picker" {
     parent?: any;
     disabled?: boolean;
     selected?: boolean;
-    viewStyle?: StyleProp<ViewStyle>,
-    textStyle?: StyleProp<TextStyle>,
+    viewStyle?: StyleProp<ViewStyle>;
+    textStyle?: StyleProp<TextStyle>;
+  };
+
+  export type DropDownPickerInstanceType = {
+    open: () => void;
+    close: () => void;
+    toggle: () => void;
+    reset: () => void;
+    resetItems: (items: ItemType[], defaultValue: any) => void;
+    selectItem: (value: any) => void;
+    addItem: (item: ItemType) => void;
+    addItems: (items: ItemType[]) => void;
+    removeItem: (
+      value: any,
+      params: {
+        changeDefaultValue?: boolean;
+      }
+    ) => void;
+    isOpen: () => boolean;
   };
 
   export type DropDownPickerProps = {
@@ -66,20 +84,7 @@ declare module "react-native-dropdown-picker" {
     containerProps?: ViewProps;
     globalTextStyle?: StyleProp<TextStyle>;
     childrenContainerStyle?: StyleProp<ViewStyle>;
-    controller?: (instance: {
-      open: () => void;
-      close: () => void;
-      toggle: () => void;
-      reset: () => void;
-      resetItems: (items: ItemType[], defaultValue: any) => void;
-      selectItem: (value: any) => void;
-      addItem: (item: ItemType) => void;
-      addItems: (items: ItemType[]) => void;
-      removeItem: (value: any, params: {
-        changeDefaultValue?: boolean;
-      }) => void;
-      isOpen: () => boolean;
-    }) => void;
+    controller?: (instance: DropDownPickerInstanceType) => void;
     onOpen?: () => void;
     onClose?: () => void;
     onChangeItem?: (item: any, index: number) => void;


### PR DESCRIPTION
Sometimes help if you can export types that are used on callback props. I have a component on my Typescript project that needs to know the type of the param `instance` from the `controller` callback.
I resolve this using some utility types:

```typescript
type ControllerType = DropDownPickerProps['controller'];
type NonNullableControllerType = NonNullable<ControllerType>;
type ControllerArgs = Parameters<NonNullableControllerType>;
export type DropDownPickerInstanceType = ControllerArgs[0];

functions MyComponent(props) {
let dropdownControllerInstance: DropDownControllerInstanceType;
...
}
```
Will be much easier if this library exports the type.
