### PR TITLE
Selected items as objects callback when multiple

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ Select multiple items.
 import Icon from 'react-native-vector-icons/Feather';
 
 this.state = {
-    countryValues: ['uk'],
-    countries: [{label: 'UK', value: 'uk', icon: () => <Icon name="flag" size={18} color="#900"/> }]
+    selectedCountriesValues: ['uk'],
+    selectedCountries: [{label: 'UK', value: 'uk', icon: () => <Icon name="flag" size={18} color="#900"/> }]
 }
 
 <DropDownPicker
@@ -124,10 +124,10 @@ this.state = {
         justifyContent: 'flex-start'
     }}
     onChangeItem={item => this.setState({
-        countryValues: item // an array of the selected items values
+        selectedCountriesValues: item // an array of the selected items values
     })}
     onChangeItemMultiple={item => this.setState({
-        countries: item // an array of the selected items
+        selectedCountries: item // an array of the selected items
     })}
 />
 ```

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ Select multiple items.
 import Icon from 'react-native-vector-icons/Feather';
 
 this.state = {
-    countries: ['uk']
+    countryValues: ['uk'],
+    countries: [{label: 'UK', value: 'uk', icon: () => <Icon name="flag" size={18} color="#900"/> }]
 }
 
 <DropDownPicker
@@ -123,6 +124,9 @@ this.state = {
         justifyContent: 'flex-start'
     }}
     onChangeItem={item => this.setState({
+        countryValues: item // an array of the selected items values
+    })}
+    onChangeItemMultiple={item => this.setState({
         countries: item // an array of the selected items
     })}
 />
@@ -674,4 +678,5 @@ dropDownStyle={{marginTop: 2}}
 | `onOpen`                         | Fires when you open the picker.                                                                                  | `func`                    | `() => {}`                     | No       |
 | `onClose`                        | Fires when you close the picker.                                                                                 | `func`                    | `() => {}`                     | No       |
 | `onChangeItem`                   | Callback which returns `item` and `index`. The `item` is the selected object or an array of the selected values. | `func`                    | `(item, index) => {}`          | No       |
+| `onChangeItemMultiple`                   | Callback which returns `item`. The `item` is an array of the selected objects. Only when `multiple={true}`. | `func`                    | `(item, index) => {}`          | No       |
 | `onChangeList`                   | Changes the list of items.                                                                                       | `(items, callback) => {}` | No                             |

--- a/index.d.ts
+++ b/index.d.ts
@@ -88,6 +88,7 @@ declare module "react-native-dropdown-picker" {
     onOpen?: () => void;
     onClose?: () => void;
     onChangeItem?: (item: any, index: number) => void;
+    onChangeItemMultiple?: (item: any) => void;
     onChangeList?: (items: any, callback: () => void) => void;
     renderSeperator?: () => JSX.Element;
   };

--- a/src/index.js
+++ b/src/index.js
@@ -151,6 +151,7 @@ class DropDownPicker extends React.Component {
     reset() {
         const item = this.props.multiple ? [] : this.null();
         this.props.onChangeItem(item, -1);
+        if (this.props.multiple) this.props.onChangeItemMultiple(item)
     }
 
     null() {
@@ -316,6 +317,7 @@ class DropDownPicker extends React.Component {
 
             // onChangeItem callback
             this.props.onChangeItem(choice.map(i => i.value));
+            this.props.onChangeItemMultiple(choice);
         }
 
         // onClose callback (! multiple)
@@ -625,6 +627,7 @@ DropDownPicker.defaultProps = {
     onOpen: () => {},
     onClose: () => {},
     onChangeItem: () => {},
+    onChangeItemMultiple: () => {},
     onChangeList: () => {},
 };
 


### PR DESCRIPTION
@hossein-zare PR for this issue:
https://github.com/hossein-zare/react-native-dropdown-picker/issues/213

Added a new callback to get the selected items as an array of object when `multiple` prop is true.

I noticed that `reset` method doesn't reset the state of the picker, leading to unwanted behaviors (selected items don't get reset for example). Is there a reason for that? 
I added a reset for the choice.