### PR TITLE
Fixes styling issue with Expo Web

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -403,6 +403,7 @@ class DropDownPicker extends React.Component {
     }
 
     adjustStylesToDirection(...presets) {
+        presets = presets.map((style) => StyleSheet.flatten(style));
         let merged = Object.assign({}, ...presets);
 
         // if we show dropdown box above, we need to invert border radius


### PR DESCRIPTION
Using Expo Web SDK 41 Beta, styles are passed to `adjustStylesToDirection` as Stylesheet IDs. This change flattens the object to ensure the styles are set correctly.