### PR TITLE
removed unused "thene" field in RenderBadgeItemPropsInterface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -101,6 +101,7 @@ declare module "react-native-dropdown-picker" {
       disabledItemLabelStyle: StyleProp<TextStyle>;
       categorySelectable: boolean;
       onPress: () => void;
+      theme: string;
       THEME: object;
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,7 +72,6 @@ declare module "react-native-dropdown-picker" {
       showBadgeDot: boolean;
       onPress: (value: ValueType) => void;
       rtl: boolean;
-      thene: string;
       THEME: object;
     }
 


### PR DESCRIPTION
I did this because it appears to be a misspelling of "theme" and doesn't appear (separately from THEME) in RenderBadgeItem.js