### PR TITLE
tweaked no-explicit-any linting options

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,6 @@ module.exports = {
         }
     },
     "rules": {
-        "@typescript-eslint/no-explicit-any": ["error"]
+        "@typescript-eslint/no-explicit-any": ["error", { "ignoreRestArgs": false, "fixToUnknown": false }]
     }
 };


### PR DESCRIPTION
I changed the options for the rule to disallow using "any" types explicitly to be more useful.