### PR TITLE
renamed ThemeType to ThemeNameType and made abstraction ThemeType to be finished in the future

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -72,7 +72,7 @@ declare module "react-native-dropdown-picker" {
       showBadgeDot: boolean;
       onPress: (value: ValueType) => void;
       rtl: boolean;
-      THEME: object;
+      THEME: ThemeType;
     }
 
     export interface RenderListItemPropsInterface {
@@ -102,7 +102,7 @@ declare module "react-native-dropdown-picker" {
       categorySelectable: boolean;
       onPress: () => void;
       theme: ThemeNameType;
-      THEME: object;
+      THEME: ThemeType;
     }
 
     export interface ActivityIndicatorComponentPropsInterface {
@@ -120,6 +120,7 @@ declare module "react-native-dropdown-picker" {
 
     export type DropDownDirectionType = "DEFAULT" | "TOP" | "BOTTOM" | "AUTO";
     export type ThemeNameType = "DEFAULT" | "LIGHT" | "DARK" | string;
+    export type ThemeType = object; //TODO: give this a specific type; maybe something like StyleSheet.Styles? or an object of all the fields in each type definition in the source files
     export type SetStateType = (state: any, callback?: () => void) => void;
   
     export type DropDownPickerProps = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -101,7 +101,7 @@ declare module "react-native-dropdown-picker" {
       disabledItemLabelStyle: StyleProp<TextStyle>;
       categorySelectable: boolean;
       onPress: () => void;
-      theme: ThemeType;
+      theme: ThemeNameType;
       THEME: object;
     }
 
@@ -119,7 +119,7 @@ declare module "react-native-dropdown-picker" {
     }
 
     export type DropDownDirectionType = "DEFAULT" | "TOP" | "BOTTOM" | "AUTO";
-    export type ThemeType = "DEFAULT" | "LIGHT" | "DARK" | string;
+    export type ThemeNameType = "DEFAULT" | "LIGHT" | "DARK" | string;
     export type SetStateType = (state: any, callback?: () => void) => void;
   
     export type DropDownPickerProps = {
@@ -219,7 +219,7 @@ declare module "react-native-dropdown-picker" {
       zIndexInverse?: number;
       disableLocalSearch?: boolean;
       dropDownDirection?: DropDownDirectionType;
-      theme?: ThemeType;
+      theme?: ThemeNameType;
       rtl?: boolean;
     };
 
@@ -232,7 +232,7 @@ declare module "react-native-dropdown-picker" {
       DROPDOWN_DIRECTION: DropDownDirectionType;
       SCHEMA: SchemaInterface;
       LANGUAGE: LanguageType;
-      THEMES: ThemeType;
+      THEMES: ThemeNameType;
       HELPER: {
         GET_SELECTED_ITEM: (items: ItemType[], value: string | number | null, key?: string) => GetSelectedItemOutputType;
         GET_SELECTED_ITEMS: (items: ItemType[], values: string[] | number[] | null, key?: string) => GetSelectedItemsOutputType;
@@ -242,7 +242,7 @@ declare module "react-native-dropdown-picker" {
       setListMode: (mode: string) => void;
       setDropDownDirection: (direction: DropDownDirectionType) => void;
       setTheme: (name: string) => void;
-      addTheme: (name: string, theme: ThemeType) => void;
+      addTheme: (name: string, theme: ThemeNameType) => void;
       setLanguage: (language: string) => void;
       addTranslation: (language: string, translation: TranslationInterface) => void;
       modifyTranslation: (language: string, translation: TranslationInterface) => void;


### PR DESCRIPTION
I renamed ThemeType to ThemeNameType to be more descriptive and stop the conflict with a potential future ThemeType. I then made the ThemeType type to abstract its type in the future. For now, its just = object but it allows the types of THEME parameters to be set in one place in the future.