### PR TITLE
Added Prettier code formatter and more ESLint plugins

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,15 +6,28 @@ module.exports = {
         'react',
         "react-hooks",
         "react-native",
-        "jsx-a11y"
+        "prettier",
+        "jsx-a11y",
+        "eslint-comments",
+        "import"
     ],
     extends: [
         'eslint:recommended',
         'plugin:@typescript-eslint/recommended',
+        'airbnb-typescript',
+        "airbnb",
+        "airbnb/hooks",
         "plugin:react/recommended",
         "plugin:react-hooks/recommended",
         "plugin:react-native/all",
-        "plugin:jsx-a11y/strict"
+        "prettier",
+        "plugin:prettier/recommended",
+        "plugin:jsx-a11y/recommended",
+        "plugin:eslint-comments/recommended",
+        "plugin:import/errors",
+        "plugin:import/errors",
+        "plugin:import/warnings",
+        "plugin:import/typescript"
     ],
     env: {
         node: true,
@@ -23,9 +36,52 @@ module.exports = {
     "parserOptions": {
         "ecmaFeatures": {
             "jsx": true
-        }
+        },
+        "ecmaVersion": 2020,
+        "sourceType": "module",
+        "project": "./tsconfig.json"
     },
     "rules": {
-        "@typescript-eslint/no-explicit-any": ["error", { "ignoreRestArgs": false, "fixToUnknown": false }]
-    }
+        "@typescript-eslint/no-explicit-any": ["error", { "ignoreRestArgs": false, "fixToUnknown": false }],
+        "import/no-unresolved": 0,
+        "react/jsx-filename-extension": [1, {
+            "extensions": [
+                ".ts",
+                ".tsx",
+                ".js",
+                ".jsx"
+            ]
+        }],
+        "prettier/prettier": [
+            "error",
+            {
+                // documented at: https://prettier.io/docs/en/configuration.html
+                "printWidth": 80,
+                "tabWidth": 2,
+                "useTabs": false,
+                "semi": true,
+                "singleQuote": true,
+                "quoteProps": "consistent",
+                "jsxSingleQuote": true,
+                "trailingComma": "all",
+                "bracketSpacing": true,
+                "jsxBracketSameLine": true,
+                "arrowParens": "always",
+                "requirePragma": false,
+                "insertPragma": false,
+                "proseWrap": "preserve",
+                "htmlWhitespaceSensitivity": "css",
+                "endOfLine": "lf",
+                "embeddedLanguageFormatting": "auto"
+            }
+        ],
+        "no-use-before-define": "off",
+        "@typescript-eslint/no-use-before-define": ["error"],
+        "import/extensions": ["error", "never"],
+        "react/prop-types": 0,
+        "no-shadow": "off",
+        "@typescript-eslint/no-shadow": ["error"],
+        "no-undef": "off"
+    },
+    "ignorePatterns": [".eslintrc.js"]
 };

--- a/package.json
+++ b/package.json
@@ -53,10 +53,17 @@
     "@typescript-eslint/eslint-plugin": "^4.22.1",
     "@typescript-eslint/parser": "^4.22.1",
     "eslint": "^7.25.0",
+    "eslint-config-airbnb": "^18.2.1",
+    "eslint-config-airbnb-typescript": "^12.3.1",
+    "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.23.2",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-react-native": "^3.10.0",
+    "prettier": "^2.2.1",
     "typescript": "^4.2.4"
   }
 }


### PR DESCRIPTION
This pull request adds more ESLint plugins to run checks on your code as well as the [Prettier](https://prettier.io/) code formatter. Prettier is installed as part of ESLint and will automatically check your code is consistent in its styling and follows rules you define, for example consistently using double or single quotes and not using both. I have tried to capture how you code but you can change the settings in the prettier rules in .eslintrc.js. You can automatically fix ESLint problems (which includes Prettier since the two are linked) by running "eslint --fix" or with an IDE. Most have the functionality built-in or available with add-ons, such as [this VSCode extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint). You can even set this to happen when you save files in an IDE, after commits, or after commits and pull requests in GitHub actions (or both).