### PR TITLE
Fix android dropdown bug

### DIFF
--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -1542,9 +1542,15 @@ function Picker({
         pickerRef.current = ref
     }, []);
 
+    /**
+     * Pointer events.
+     * @returns {string}
+     */
+    const pointerEvents = useMemo(() => disabled ? "none" : "auto", [disabled]);
+
     return (
         <View style={_containerStyle} {...containerProps}>
-            <TouchableOpacity style={_style} onPress={__onPress} onLayout={__onLayout} {...props} ref={onRef} disabled={disabled}>
+            <TouchableOpacity style={_style} onPress={__onPress} onLayout={__onLayout} {...props} ref={onRef} pointerEvents={pointerEvents} disabled={disabled}>
                 {_BodyComponent}
                 {_ArrowComponent}
             </TouchableOpacity>

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -1542,15 +1542,9 @@ function Picker({
         pickerRef.current = ref
     }, []);
 
-    /**
-     * Pointer events.
-     * @returns {string}
-     */
-    const pointerEvents = useMemo(() => disabled ? "none" : "auto", [disabled]);
-
     return (
-        <View style={_containerStyle} {...containerProps} pointerEvents={pointerEvents}>
-            <TouchableOpacity style={_style} onPress={__onPress} onLayout={__onLayout} {...props} ref={onRef}>
+        <View style={_containerStyle} {...containerProps}>
+            <TouchableOpacity style={_style} onPress={__onPress} onLayout={__onLayout} {...props} ref={onRef} disabled={disabled}>
                 {_BodyComponent}
                 {_ArrowComponent}
             </TouchableOpacity>


### PR DESCRIPTION
pointerEvents props is causing dropdown menu going under other components on Android devices.
Instead of using pointerEvents I have added disabled props directly to the TochableOpacity.