### PR TITLE
Fix TypeScript error: Exports and export assignments are not permitted in module augmentations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,18 @@
-import {ComponentType, SetStateAction, Dispatch} from "react";
-import {
-    FlatListProps,
-    LayoutChangeEvent,
-    ModalProps,
-    ScrollViewProps,
-    StyleProp,
-    TextInputProps,
-    TextProps,
-    TextStyle,
-    ViewProps,
-    ViewStyle
-} from "react-native";
-
 declare module "react-native-dropdown-picker" {
+    import type {ComponentType, SetStateAction, Dispatch} from "react";
+    import type {
+        FlatListProps,
+        LayoutChangeEvent,
+        ModalProps,
+        ScrollViewProps,
+        StyleProp,
+        TextInputProps,
+        TextProps,
+        TextStyle,
+        ViewProps,
+        ViewStyle
+    } from "react-native";
+
     export type ValueType = string | number | boolean;
 
     export type ItemType = {


### PR DESCRIPTION
We are seeing this error with the latest version `5.1.19`
```
node_modules/react-native-dropdown-picker/index.d.ts:252:5 - error TS2666: Exports and export assignments are not permitted in module augmentations.
252     export default DropDownPicker;
        ~~~~~~
Found 1 error.
```

Should be fixed by moving the imports inside the module declaration.