### PR TITLE
Remove __onLayout e.persist on web

### DIFF
--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -537,7 +537,8 @@ function Picker({
      * onLayout.
      */
     const __onLayout = useCallback((e) => {
-        e.persist();
+        if(Platform !== "web")
+            e.persist();
 
         onLayout(e);
 


### PR DESCRIPTION
Throws error without visibly changing anything when patched out.
Error happens with: 
Expo-Web (works on iOS/Android)

Occurs on component mount