### PR TITLE
Fix type with Platform.OS not including the OS part (doh)

### DIFF
--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -537,7 +537,7 @@ function Picker({
      * onLayout.
      */
     const __onLayout = useCallback((e) => {
-        if(Platform !== "web")
+        if(Platform.OS !== "web")
             e.persist();
 
         onLayout(e);


### PR DESCRIPTION
The actual important part (lol) `.OS` seems to have escaped the previous pull request/commit.