### PR TITLE
Prepare for release v5.1.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-dropdown-picker",
-  "version": "5.1.21",
+  "version": "5.1.23",
   "description": "A single / multiple, categorizable, customizable, localizable and searchable item picker (drop-down) component for react native which supports both Android & iOS.",
   "keywords": [
     "picker",


### PR DESCRIPTION
Note v5.1.22 was tagged, but package.json was not incremented, so npmjs.com publish failed
and v5.1.22 was not officially released to npmjs.com
This release (v5.1.23) is equivalent in all ways except the tag name / version number.