### PR TITLE
fix: categories dont work as expected #397

### DIFF
--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -311,7 +311,7 @@ function Picker({
         const children = items.filter(item => item[_schema.parent] !== undefined && item[_schema.parent] !== null);
 
         children.forEach((child) => {
-            const index = items.findIndex(item => item[_schema.parent] === child[_schema.parent] || item[_schema.value] === child[_schema.parent]);
+            const index = sortedItems.findIndex(item => item[_schema.parent] === child[_schema.parent] || item[_schema.value] === child[_schema.parent]);
 
             if (index > -1) {
                 sortedItems.splice(index + 1, 0, child);


### PR DESCRIPTION
Turns out it was unrelated to Hermes (TIL chrome debugger does not use hermes engine if it's enabled on device...). As long as values are unique as stated in the rules everything is fine now. 
However, while child order does not matter, parent order does. This is a non issue, but it's a bit confusing with how it's described in the current docs.