### PR TITLE
Feature sticky header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 
 package-lock.json
+.vscode/*

--- a/index.d.ts
+++ b/index.d.ts
@@ -188,6 +188,7 @@ declare module "react-native-dropdown-picker" {
       showArrowIcon?: boolean;
       showBadgeDot?: boolean;
       showTickIcon?: boolean;
+      stickyHeader?: boolean;
       ArrowUpIconComponent?: (props: {style: StyleProp<ViewStyle>}) => JSX.Element;
       ArrowDownIconComponent?: (props: {style: StyleProp<ViewStyle>}) => JSX.Element;
       TickIconComponent?: (props: {style: StyleProp<ViewStyle>}) => JSX.Element;

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -113,6 +113,7 @@ function Picker({
     showArrowIcon = true,
     showBadgeDot = true,
     showTickIcon = true,
+    stickyHeader = false,
     ArrowUpIconComponent = null,
     ArrowDownIconComponent = null,
     TickIconComponent = null,
@@ -319,7 +320,25 @@ function Picker({
         });
 
         return sortedItems;
-    }, [items, _schema])
+    }, [items, _schema]);
+
+    /**
+     * The indices of all parent items.
+     * @returns {object}
+     */
+     const stickyHeaderIndices = useMemo(() => {
+        const stickyHeaderIndices = [];
+        if (stickyHeader) {
+            const parents = sortedItems.filter(item => item[_schema.parent] === undefined || item[_schema.parent] === null);
+            parents.forEach((parent) => {
+                const index = sortedItems.findIndex(item => item[_schema.value] === parent[_schema.value]);
+                if (index > -1) stickyHeaderIndices.push(index);
+            })
+
+        }
+        return stickyHeaderIndices;
+
+    }, [stickyHeader, sortedItems])
 
     /**
      * The items.
@@ -982,7 +1001,8 @@ function Picker({
      */
     const _listItemContainerStyle = useMemo(() => ([
         RTL_DIRECTION(rtl, THEME.listItemContainer),
-        ...[listItemContainerStyle].flat()
+        ...[listItemContainerStyle].flat(),
+        stickyHeader && {backgroundColor: THEME.style.backgroundColor},
     ]), [rtl, listItemContainerStyle, THEME]);
 
     /**
@@ -1465,6 +1485,7 @@ function Picker({
             keyExtractor={keyExtractor}
             extraData={_value}
             ItemSeparatorComponent={ItemSeparatorComponent}
+            stickyHeaderIndices={stickyHeaderIndices}
             {...flatListProps}
         />
     ), [
@@ -1484,7 +1505,7 @@ function Picker({
      */
     const DropDownScrollViewComponent = useMemo(() => {
         return (
-            <ScrollView nestedScrollEnabled={true} {...scrollViewProps}>
+            <ScrollView nestedScrollEnabled={true} stickyHeaderIndices={stickyHeaderIndices} {...scrollViewProps} >
                 {_items.map((item, index) => { 
                     return (
                         <Fragment key={item[_itemKey]}>

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -311,7 +311,7 @@ function Picker({
         const children = items.filter(item => item[_schema.parent] !== undefined && item[_schema.parent] !== null);
 
         children.forEach((child) => {
-            const index = items.findIndex(item => item[_schema.parent] === child[_schema.parent] || item[_schema.value] === child[_schema.parent]);
+            const index = sortedItems.findIndex(item => item[_schema.parent] === child[_schema.parent] || item[_schema.value] === child[_schema.parent]);
 
             if (index > -1) {
                 sortedItems.splice(index + 1, 0, child);


### PR DESCRIPTION
Not sure if this is useful for anyone but I needed it for one of my projects so I thought I might as well share it.
This feature adds the option to have categories treated as sticky headers while scrolling:
```
    <DropDownPicker
      open={open}
      value={value}
      items={items}
      setOpen={setOpen}
      setValue={setValue}
      setItems={setItems}
      stickyHeader
    />
```
![StickHeaderDemo](https://user-images.githubusercontent.com/32298241/131685264-58a688b8-0d63-4488-9bbf-3c24a2badc21.gif)
**Notes**
- I had to set a background color in order to not make the items overlap with the sticky headers. I **only do so if stickyHeader is set to true**, to avoid any android touch not registered nonsense. But it worked fine in my tests. 
- Indices for parents are only calculated when set to true, so no runtime penalty whatsoever