### PR TITLE
feat: add testID to ItemType and set on item TouchableOpacity

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ declare module "react-native-dropdown-picker" {
       parent?: ValueType;
       selectable?: boolean;
       disabled?: boolean;
+      testID?: string;
     };
 
     export type ModeType  = "DEFAULT" | "SIMPLE" | "BADGE";

--- a/src/components/RenderListItem.js
+++ b/src/components/RenderListItem.js
@@ -149,7 +149,7 @@ function RenderListItem({
     }, [onPress, parent, categorySelectable, custom]);
 
     return (
-        <TouchableOpacity style={_listItemContainerStyle} onPress={__onPress} disabled={selectable === false || disabled}>
+        <TouchableOpacity style={_listItemContainerStyle} onPress={__onPress} disabled={selectable === false || disabled} testID={item.testID}>
             {IconComponent}
             <Text style={_listItemLabelStyle}>
                 {label}


### PR DESCRIPTION
This adds a `testID` prop to the ItemType, allowing various testing frameworks to tap on the items within the dropdown list. This is an optional prop so if nothing is passed for this value the testID is simply undefined.

Here is an example of a test run using jest and `@testing-library/react-native` which shows the testID has been applied to the dropdown item as expected.

![Screenshot 2021-09-22 at 16 34 16](https://user-images.githubusercontent.com/57176809/134374830-388336be-c7ef-473a-8725-ea943fe8df51.png)

Fixes #377