### PR TITLE
Updated setState types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -270,7 +270,7 @@ declare module 'react-native-dropdown-picker' {
     multiple?: false;
     onChangeValue?: (value: T | null) => void;
     onSelectItem?: (item: ItemType<T>) => void;
-    setValue: Dispatch<SetStateCallback<T | null>>;
+    setValue: Dispatch<SetStateCallback<T | null | any>>;
     value: T | null;
   }
 
@@ -278,7 +278,7 @@ declare module 'react-native-dropdown-picker' {
     multiple: true;
     onChangeValue?: (value: T[] | null) => void;
     onSelectItem?: (items: ItemType<T>[]) => void;
-    setValue: Dispatch<SetStateCallback<T[] | null>>;
+    setValue: Dispatch<SetStateCallback<T[] | null | any>>;
     value: T[] | null;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module 'react-native-dropdown-picker' {
-  import type { SetStateAction, Dispatch, PropsWithoutRef } from 'react';
+  import type { Dispatch, PropsWithoutRef } from 'react';
   import type {
     FlatListProps,
     LayoutChangeEvent,
@@ -13,6 +13,9 @@ declare module 'react-native-dropdown-picker' {
     TouchableOpacityProps,
     ViewStyle,
   } from 'react-native';
+
+  type SetStateCallback<S> = ((prevState: S) => S);
+  type SetStateValue<S> = ((prevState: S) => S);
 
   export type ValueType = string | number | boolean;
 
@@ -243,8 +246,8 @@ declare module 'react-native-dropdown-picker' {
     min?: number;
     max?: number;
     addCustomItem?: boolean;
-    setOpen: Dispatch<SetStateAction<boolean>>;
-    setItems?: Dispatch<SetStateAction<any[]>>;
+    setOpen: Dispatch<SetStateValue<boolean>>;
+    setItems?: Dispatch<SetStateCallback<any[]>>;
     disableBorderRadius?: boolean;
     containerProps?: ViewProps;
     onLayout?: (e: LayoutChangeEvent) => void;
@@ -267,7 +270,7 @@ declare module 'react-native-dropdown-picker' {
     multiple?: false;
     onChangeValue?: (value: T | null) => void;
     onSelectItem?: (item: ItemType<T>) => void;
-    setValue: Dispatch<SetStateAction<T | null>>;
+    setValue: Dispatch<SetStateCallback<T | null>>;
     value: T | null;
   }
 
@@ -275,7 +278,7 @@ declare module 'react-native-dropdown-picker' {
     multiple: true;
     onChangeValue?: (value: T[] | null) => void;
     onSelectItem?: (items: ItemType<T>[]) => void;
-    setValue: Dispatch<SetStateAction<T[] | null>>;
+    setValue: Dispatch<SetStateCallback<T[] | null>>;
     value: T[] | null;
   }
 


### PR DESCRIPTION
The types specified for `SetValue`, `SetOpen` and `SetItems` are incorrect because we explicitly pass a call back or a value in the Picker. The types used were the generic React Types for SetState

For example see `SetValue` [here](https://github.com/hossein-zare/react-native-dropdown-picker/blob/743acd6eaaa28f149cd025d7108c97dbe8ff6de1/src/components/Picker.js#L1229-L1254): https://github.com/hossein-zare/react-native-dropdown-picker/blob/743acd6eaaa28f149cd025d7108c97dbe8ff6de1/src/components/Picker.js#L1229-L1254