### PR TITLE
feat: Add itemLabelProps

### DIFF
--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -129,6 +129,7 @@ function Picker({
     activityIndicatorColor = Colors.GREY,
     props = {},
     itemProps = {},
+    itemLabelProps = {},
     badgeProps= {},
     modalProps = {},
     flatListProps = {},
@@ -1446,6 +1447,7 @@ function Picker({
                 disabled={item?.[_schema.disabled] ?? false}
                 custom={item.custom ?? false}
                 props={itemProps}
+                labelProps={itemLabelProps}
                 isSelected={isSelected}
                 IconComponent={IconComponent}
                 TickIconComponent={_TickIconComponent}
@@ -1492,6 +1494,7 @@ function Picker({
         _value,
         multiple,
         itemProps,
+        itemLabelProps,
         categorySelectable,
         onPressItem,
         theme,

--- a/src/components/RenderListItem.js
+++ b/src/components/RenderListItem.js
@@ -20,6 +20,7 @@ function RenderListItem({
     selectable,
     disabled,
     props,
+    labelProps,
     custom,
     isSelected,
     IconComponent,
@@ -164,7 +165,7 @@ function RenderListItem({
     return (
         <TouchableOpacity style={_listItemContainerStyle} onPress={__onPress} onLayout={onLayout} {...props} disabled={selectable === false || disabled} testID={item.testID}>
             {IconComponent}
-            <Text style={_listItemLabelStyle}>
+            <Text style={_listItemLabelStyle} {...labelProps}>
                 {label}
             </Text>
             {_TickIconComponent}


### PR DESCRIPTION
This PR adds `itemLabelProps` to allow developers to pass props directly to the `Text` component inside the item.

This could address issues like https://github.com/hossein-zare/react-native-dropdown-picker/issues/460:

```
itemLabelProps={{
    numberOfLines: 1
}}
```