### PR TITLE
Fix: select item multiple enabled

### DIFF
--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -1263,7 +1263,7 @@ function Picker({
 
         // Not a reliable method for external value changes.
         if (multiple) {
-            if (memoryRef.current.value.includes(item[_schema.value])) {
+            if (memoryRef.current.value?.includes(item[_schema.value])) {
                 const index = memoryRef.current.items.findIndex(x => x[_schema.value] === item[_schema.value]);
 
                 if (index > -1) {
@@ -1279,7 +1279,7 @@ function Picker({
 
         setValue(state => {
             if (multiple) {
-                let _state = state !== null ? [...state] : [];
+                let _state = state !== null && state !== undefined  ? [...state] : [];
 
                 if (_state.includes(item[_schema.value])) {
                     // Remove the value


### PR DESCRIPTION
In this PR:
* Added a verification for value in `if (memoryRef.current.value.includes(item[_schema.value]))`, when multiple is enable otherwise I get this error:

<img width="407" alt="image" src="https://user-images.githubusercontent.com/32428883/171161767-bffb522a-44f4-4072-bf42-b187dd9300c7.png">

* Added also a check for `state !== undefined` in `setValue` otherwise this issue is raised:

<img width="407" alt="image" src="https://user-images.githubusercontent.com/32428883/171162461-910af833-0501-4ef6-97db-f8812633f38c.png">
