### PR TITLE
support a `modalAnimationType` prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -176,6 +176,7 @@ declare module 'react-native-dropdown-picker' {
     searchPlaceholderTextColor?: string;
     dropDownContainerStyle?: StyleProp<ViewStyle>;
     modalContentContainerStyle?: StyleProp<ViewStyle>;
+    modalAnimationType?: 'none' | 'slide' | 'fade';
     arrowIconContainerStyle?: StyleProp<ViewStyle>;
     closeIconContainerStyle?: StyleProp<ViewStyle>;
     tickIconContainerStyle?: StyleProp<ViewStyle>;

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -75,6 +75,7 @@ function Picker({
     searchPlaceholderTextColor = Colors.GREY,
     dropDownContainerStyle = {},
     modalContentContainerStyle = {},
+    modalAnimationType = 'none',
     arrowIconContainerStyle = {},
     closeIconContainerStyle = {},
     tickIconContainerStyle = {},
@@ -1749,7 +1750,7 @@ function Picker({
      * @returns {JSX.Element}
      */
     const DropDownModalComponent = useMemo(() => (
-        <Modal visible={open} presentationStyle="fullScreen" onRequestClose={onRequestCloseModal} {...modalProps}>
+        <Modal animationType={modalAnimationType} visible={open} presentationStyle="fullScreen" onRequestClose={onRequestCloseModal} {...modalProps}>
             <SafeAreaView style={_modalContentContainerStyle}>
                 {SearchComponent}
                 {DropDownFlatListComponent}


### PR DESCRIPTION
Simply pass it along to the ReactNative `Modal` element (docs [here](https://reactnative.dev/docs/modal#animationtype)). Takes the same type, `'none' | 'slide' | 'fade'`. Defaults to `none` to keep the existing behavior consistent.