### PR TITLE
remove unneeded error; add license badge and usage info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <p align="left">
   <a href="https://github.com/hossein-zare/react-native-dropdown-picker/blob/dev-5.x/LICENSE">
     <img src="https://img.shields.io/badge/license-MIT-blue.svg"
-      alt="React Native is released under the MIT license." />
+      alt="react-native-dropdown-picker is released under the MIT license." />
   </a>
   <a href="https://www.npmjs.org/package/react-native-dropdown-picker">
     <img src="https://img.shields.io/npm/v/react-native-dropdown-picker?color=brightgreen&label=npm%20package"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@
 The above screenshots are taken from the following
 example: [https://snack.expo.dev/8mHmLfcZf](https://snack.expo.dev/8mHmLfcZf)
 
-## Documentation
+## Usage
+
+See [the relevant documentation](https://hossein-zare.github.io/react-native-dropdown-picker-website/docs/usage).
+
+## Further documentation
 
 The docs can be read
 at: [https://hossein-zare.github.io/react-native-dropdown-picker-website](https://hossein-zare.github.io/react-native-dropdown-picker-website).

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # React Native Dropdown Picker
 
-<a href="https://www.npmjs.org/package/react-native-dropdown-picker">
-  <img src="https://img.shields.io/npm/v/react-native-dropdown-picker?color=brightgreen&label=npm%20package"
-    alt="Current npm package version." />
-</a>
+<p align="left">
+  <a href="https://github.com/hossein-zare/react-native-dropdown-picker/blob/dev-5.x/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue.svg"
+      alt="React Native is released under the MIT license." />
+  </a>
+  <a href="https://www.npmjs.org/package/react-native-dropdown-picker">
+    <img src="https://img.shields.io/npm/v/react-native-dropdown-picker?color=brightgreen&label=npm%20package"
+      alt="Current npm package version." />
+  </a>
+</p>
 
 ## Screenshots
 

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -49,27 +49,6 @@ import RenderListItem from './RenderListItem';
 
 const { height: WINDOW_HEIGHT } = Dimensions.get('window');
 
-/**
- * Find whether two value arrays (value prop and memoryRef.current.value) have the same values.
- * === will just check if arrays are the same reference, not if their values are the same.
- * @param valueOne first array
- * @param valueTwo second array
- * @returns boolean representing whether the two values are the same.
- */
-function areValueArraysEqual(valueOne, valueTwo) {
-  if (Array.isArray(valueOne) !== Array.isArray(valueTwo)) return false;
-
-  if (!Array.isArray(valueOne)) return valueOne === valueTwo;
-
-  if (valueOne.length !== valueTwo.length) return false;
-
-  for (let i = 0; i < valueOne.length; i += 1) {
-    if (valueOne[i] !== valueTwo[i]) return false;
-  }
-
-  return true;
-}
-
 function Picker({
   items = [],
   setItems = () => {},
@@ -1425,16 +1404,6 @@ function Picker({
    */
   const onPressItem = useCallback(
     (item, customItem = false) => {
-      if (!areValueArraysEqual(value, memoryRef.current.value)) {
-        throw new Error(
-          `${new Date().toString()} The arrays of the value prop and memoryRef.current.value were not equal in the callback for when items are pressed in the Picker component. value was: ${JSON.stringify(
-            value,
-          )} and memoryRef.current.value was: ${JSON.stringify(
-            memoryRef.current.value,
-          )}`,
-        );
-      }
-
       // if pressed item was a custom item by the user, add it to the list of items (?)
       if (customItem !== false) {
         item.custom = false;


### PR DESCRIPTION
- remove unneeded error when value prop != memoryRef.value.current at the start of the item press callback; I thought they should remain consistent but found in testing dropdowns work even when they aren't
- add licence badge and link to usage info to readme