### PR TITLE
Fix: modalTitleStyle overwritten by textStyle

### DIFF
--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -1737,8 +1737,8 @@ function Picker({
   const _modalTitleStyle = useMemo(
     () => [
       THEME.modalTitle,
+       ...[textStyle].flat(),
       ...[modalTitleStyle].flat(),
-      ...[textStyle].flat(),
     ],
     [textStyle, modalTitleStyle, THEME],
   );


### PR DESCRIPTION
Fix: modalTitleStyle overwritten by textStyle

refer to this issue : https://github.com/hossein-zare/react-native-dropdown-picker/issues/741#issue-2130715283