### PR TITLE
chore: added issue templates to enable contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,98 @@
+---
+name: "🐛 Bug Report"
+about: Report a bug in the library.
+title: 'Bug: '
+labels: [ 'bug report' ]
+---
+
+<!--
+Thank you for reporting an issue with this library!
+Please fill out all the information below about the bug you've found.
+Doing so helps us to fix it ASAP 😃
+-->
+
+## ✅ Checklist
+
+- [ ] I have searched
+  through [this library's GitHub issues](https://github.com/hossein-zare/react-native-dropdown-picker/issues),
+  and I am confident that this bug report is not a duplicate.
+- [ ] I have checked and my bug is present
+  in [the latest version of this library](https://www.npmjs.com/package/react-native-dropdown-picker).
+- [ ] I have searched
+  through [this library's GitHub issues](https://github.com/hossein-zare/react-native-dropdown-picker/issues)
+  and [this library's docs](https://hossein-zare.github.io/react-native-dropdown-picker-website/docs),
+  and I am confident that this is indeed a bug rather than simply something I
+  don't know how to do (if so, make a question/help issue instead).
+- [ ] I am reporting a bug with the library, not requesting that more
+  functionality is added to it (if so, make a feature request issue instead).
+- [ ] My bug comes from this library and not others, e.g. React Native or
+  another dependency in my project.
+- [ ] I understand that each bug should be submitted in its own issue.
+  Therefore, this issue will contain only one bug. I will submit any other bugs
+  I have in their own, separate issues.
+
+## ⚠️ The problem
+
+### Desired (expected, correct) behaviour
+
+<!--
+Please describe how this library should behave and act.
+This will be the proper behaviour that should be seen, but isn't because of the bug.
+-->
+
+### Actual (unexpected, incorrect) behaviour
+
+<!--
+Please describe how this library actually does act.
+This will be the undesired behaviour present because of the bug.
+-->
+
+### Screenshots/screen recordings
+
+<!--
+If possible, please include screenshots and/or screen recordings showing the bug.
+A picture speaks a thousand words.
+-->
+
+### Log/error output
+
+<!--
+If your bug produced any errors or logs, please copy and paste them here.
+-->
+
+### 🔁 Minimal reproducible example
+
+<!--
+Please include a link to a minimal reproducible example of the bug.
+This should be the minimum amount of code required to show the bug.
+Don't include any code or dependencies not needed for it to be present.
+If you found this bug in your project, remove everything other than the bare minimum required to reproduce and demonstrate this bug.
+
+This example might be within:
+- an Expo Snack (https://snack.expo.dev)
+- a CodeSandbox (https://codesandbox.io)
+- a GitHub repo or gist
+
+We recommend using an Expo Snack to create a minimal reproducible example.
+Here are some tips to help you: https://stackoverflow.com/help/mcve
+-->
+
+Link to minimal reproducible example: <paste_link_here>
+
+## 🏁 Final details
+
+### Steps to fix
+
+<!--
+Have you taken any steps to try to debug or fix this issue?
+If you have, what have you learnt while doing so? Did anything work?
+What insights and ideas can you give us into how we might fix this bug?
+Feel free to edit this library with patch-package (https://github.com/ds300/patch-package).
+See if you can debug or fix the issue and let us know what you find out!
+-->
+
+### Additional context/info
+
+<!--
+Please include any other information you think is relevant to this bug report.
+-->

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,84 @@
+---
+name: "🚀 Feature request"
+about: Request a new feature to be added to this library.
+title: 'Feature request: '
+labels: [ 'feature request' ]
+---
+
+<!--
+Thank you for making a feature request and helping to improve this library!
+Please fill out all the information below about your idea.
+Doing so helps us to assess its usefulness and feasibility and implement it ASAP 😃
+-->
+
+## ✅ Checklist
+
+- [ ] I have searched
+  through [this library's GitHub issues](https://github.com/hossein-zare/react-native-dropdown-picker/issues),
+  and I am confident that this feature request is not a duplicate.
+- [ ] I have searched
+  through [this library's GitHub issues](https://github.com/hossein-zare/react-native-dropdown-picker/issues)
+  and have
+  read [this library's docs](https://hossein-zare.github.io/react-native-dropdown-picker-website),
+  and I am confident that this feature request is not implemented
+  in [the latest version of this library](https://www.npmjs.com/package/react-native-dropdown-picker).
+- [ ] I am asking for some functionality to be added to this library. I am
+  not seeking help or reporting a bug (if so, make a different type of issue).
+- [ ] I understand that each feature request should be submitted in its own
+  issue. Therefore, this issue will contain only one feature request. I will
+  submit any other feature requests I have in their own, separate issues.
+
+## 🤔 Overview
+
+### Summary
+
+<!--
+Please give a brief overview and summary of this feature request.
+-->
+
+### Usefulness
+
+<!--
+Please explain in detail what value this feature request would add and why, to whom, and when it would be useful.
+-->
+
+### User story
+
+<!--
+Please write a user story encapsulating your proposed feature.
+See guidance at: https://www.atlassian.com/agile/project-management/user-stories
+-->
+
+## 💡 Details
+
+### How
+
+<!--
+Please describe any ideas you have on how this feature could be implemented.
+How would you change this library to achieve it?
+Considering the architecture of this library and your desired goals for this feature, are there any design choices to consider?
+Have you tried implementing any of this functionality with patch-package (https://www.npmjs.com/package/patch-package)?
+If so, what did you learn?
+-->
+
+### Similar/same functionality elsewhere
+
+<!--
+Do any other libraries implement functionality the same as or similar to that which you're proposing?
+If so, which ones?
+Why would it still be useful for us to implement it as well if they already have something the same or similar?
+-->
+
+### Possible alternatives
+
+<!--
+Have you considered any alternative solutions, approaches, or features?
+Please describe them if so.
+Why is your proposed feature and solution better than these alternatives?
+-->
+
+### Additional context/info
+
+<!--
+Please include any other information you think is relevant to this feature request.
+-->

--- a/.github/ISSUE_TEMPLATE/QUESTION_OR_HELP.md
+++ b/.github/ISSUE_TEMPLATE/QUESTION_OR_HELP.md
@@ -1,0 +1,103 @@
+---
+name: "🛟 Question or help"
+about: Ask a question or for help using the library.
+title: 'Question/help: '
+labels: [ 'help needed' ]
+---
+
+<!--
+Thank you for your question or problem and for using this library!
+Please fill out all the information below to get help.
+Doing so helps us to assess your question or problem and help you 😃
+-->
+
+## ✅ Checklist
+
+- [ ] I have searched
+  through [the other issues for this library](https://github.com/hossein-zare/react-native-dropdown-picker/issues),
+  and I am confident that my question/problem is not a duplicate.
+- [ ] I have checked and
+  read [this library's docs](https://hossein-zare.github.io/react-native-dropdown-picker-website)
+  to try to solve my question/problem by myself.
+- [ ] I have checked and
+  read [this library's GitHub issues](https://github.com/hossein-zare/react-native-dropdown-picker/issues)
+  to try to solve my question/problem by myself.
+- [ ] I have checked and
+  read [Stack Overflow](https://stackoverflow.com/questions/tagged/react-native-dropdown-picker)
+  to try to solve my question/problem by myself.
+- [ ] I have
+  examined [this library's examples](https://github.com/taeh98/react-native-dropdown-picker/tree/dev-5.x/examples)
+  to try to solve my question/problem by myself.
+- [ ] My question/problem relates to this library and not others, e.g. React
+  Native or another dependency in my project.
+- [ ] My question/problem is not a bug report or a feature request (if so,
+  create a different type of issue).
+- [ ] I understand that each question/problem should be submitted in its own
+  issue. Therefore, this issue will contain only one question/problem. I will
+  submit any other questions/problems I have in their own, separate issues.
+
+## 🔬 Research
+
+### Relevant docs pages
+
+<!--
+Please include the links to every docs page relevant to your question or problem.
+If there is no relevant information, please include links to the docs pages 
+which should provide relevant information. Please describe the additional 
+information they should contain. Please make an issue in the docs repo stating
+that this information should be added. The docs repo is: https://github.com/hossein-zare/react-native-dropdown-picker-website
+-->
+
+### Relevant GitHub issues
+
+<!--
+Please include links to every GitHub issue relevant to your question or problem.
+-->
+
+### Relevant Stack Overflow questions
+
+<!--
+Please include links to every Stack Overflow question relevant to your question or problem.
+-->
+
+## ⚠️ The problem
+
+### What I need help with
+
+<!--
+Please describe what your issue is, the question you have, or the help you need.
+Maybe you want to customise a DropDownPicker in a certain way but don't know how?
+Maybe you're trying to do something and have copied the docs, but it isn't working?
+-->
+
+### What I've tried already
+
+<!--
+Please describe the steps you've taken to try to fix your issue yourself.
+This might be how you tried to research a question or tried to add a function.
+-->
+
+### 🔁 Minimal reproducible example
+
+<!--
+If your problem relates to you being unable to do something, provide an MRE.
+Remove everything other than the bare minimum required to demonstrate how you're
+trying to achieve your desired outcomes and how it isn't working.
+
+This example might be within:
+- an Expo Snack (https://snack.expo.dev)
+- a CodeSandbox (https://codesandbox.io)
+- a GitHub repo or gist
+
+We recommend using an Expo Snack to create a minimal reproducible example.
+Here are some tips to help you: https://stackoverflow.com/help/mcve
+-->
+
+Link to minimal reproducible example: <paste_link_here>
+
+## 🏁 Additional context/info
+
+<!--
+Please include any other information you think is relevant to this problem/question/etc.
+Do you have any ideas or hunches on how to solve your issue?
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+---
+blank_issues_enabled: false
+contact_links:
+  - name: 📃 Documentation Issue
+    url: https://github.com/hossein-zare/react-native-dropdown-picker-website
+    about: >
+      If this library's docs are incorrect or are missing something,
+      please file an issue here.


### PR DESCRIPTION
Hey @hossein-zare, I got around to trimming down the issue templates after [you let me know](https://github.com/hossein-zare/react-native-dropdown-picker/pull/713#issuecomment-1747622086) you thought the old versions were too long. Please take a look when you can and tell me what you think :)