### PR TITLE
feat: add clear search field functionality on item select

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -196,6 +196,7 @@ declare module 'react-native-dropdown-picker' {
     containerStyle?: StyleProp<ViewStyle>;
     customItemContainerStyle?: StyleProp<ViewStyle>;
     customItemLabelStyle?: StyleProp<TextStyle>;
+    clearSearchFieldOnSelect?: boolean;
     disableBorderRadius?: boolean;
     disabledItemContainerStyle?: StyleProp<ViewStyle>;
     disabledItemLabelStyle?: StyleProp<TextStyle>;

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -83,6 +83,7 @@ function Picker({
   containerStyle = {},
   customItemContainerStyle = {},
   customItemLabelStyle = {},
+  clearSearchFieldOnSelect = false,
   disableBorderRadius = true,
   disabled = false,
   disabledItemContainerStyle = {},
@@ -347,6 +348,19 @@ function Picker({
   useEffect(() => {
     if (mode === MODE.SIMPLE) badgeFlatListRef.current = null;
   }, [mode]);
+
+  /**
+   * clear search field on item select.
+   */
+  useEffect(() => {
+    if (
+      clearSearchFieldOnSelect == true &&
+      multiple == true &&
+      searchText.length > 0
+    ) {
+      setSearchText('');
+    }
+  }, [value]);
 
   /**
    * onPressClose.


### PR DESCRIPTION
Hey @hossein-zare ,

I noticed that there’s currently no functionality to clear the search field after selecting an item when both `multiple` and  `searchable` are `true`.

I recently implemented this feature in my project, and I believe it would be a valuable addition to our package as well. I also found some open issues related to this functionality:

[Issue #622](https://github.com/hossein-zare/react-native-dropdown-picker/issues/622)
[Issue #750](https://github.com/hossein-zare/react-native-dropdown-picker/issues/750)

In this PR, I’ve added a new prop called `clearSearchFieldOnSelect`. This will clear the search field if the following conditions are met:

1. `clearSearchFieldOnSelect` should be `true`
2. `multiple` (picker) should be `true`
3. search field should not be empty

If all conditions are satisfied, `clearSearchFieldOnSelect` will clear the search field.

Please let me know if you have any feedback or if there are any changes needed!
