### PR TITLE
Fix Android edge-to-edge display issue in modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "peerDependencies": {
     "react": "^18.2.0",
-    "react-native": "^0.72.5"
+    "react-native": "^0.72.5",
+    "react-native-safe-area-context": "^4.0.0"
   }
 }

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -17,6 +17,7 @@ import {
   Modal,
   Platform,
   SafeAreaView,
+  StatusBar,
   StyleSheet,
   Text,
   TextInput,
@@ -25,6 +26,9 @@ import {
 } from 'react-native';
 
 import { FlatList, ScrollView } from 'react-native-gesture-handler';
+
+// Import SafeAreaView from react-native-safe-area-context for better edge-to-edge support
+import { SafeAreaView as SafeAreaContextView } from 'react-native-safe-area-context';
 import {
   ASCII_CODE,
   BADGE_COLORS,
@@ -889,7 +893,15 @@ function Picker({
    * @returns {object}
    */
   const _modalContentContainerStyle = useMemo(
-    () => [THEME.modalContentContainer, ...[modalContentContainerStyle].flat()],
+    () => [
+      THEME.modalContentContainer,
+      // Add edge-to-edge support for Android
+      Platform.OS === 'android' && {
+        flex: 1,
+        backgroundColor: THEME.modalContentContainer.backgroundColor || '#FFFFFF',
+      },
+      ...[modalContentContainerStyle].flat()
+    ],
     [modalContentContainerStyle, THEME],
   );
 
@@ -1924,13 +1936,20 @@ function Picker({
         presentationStyle='fullScreen'
         onRequestClose={onRequestCloseModal}
         {...modalProps}>
-        <SafeAreaView style={_modalContentContainerStyle}>
-          {SearchComponent}
-          {DropDownFlatListComponent}
-        </SafeAreaView>
+        {Platform.OS === 'android' ? (
+          <SafeAreaContextView style={_modalContentContainerStyle} edges={['top', 'bottom', 'left', 'right']}>
+            {SearchComponent}
+            {DropDownFlatListComponent}
+          </SafeAreaContextView>
+        ) : (
+          <SafeAreaView style={_modalContentContainerStyle}>
+            {SearchComponent}
+            {DropDownFlatListComponent}
+          </SafeAreaView>
+        )}
       </Modal>
     ),
-    [open, SearchComponent, _modalContentContainerStyle, modalProps],
+    [open, SearchComponent, DropDownFlatListComponent, _modalContentContainerStyle, modalProps],
   );
 
   /**


### PR DESCRIPTION
- Use SafeAreaView from react-native-safe-area-context for better edge-to-edge support on Android
- Fixes issue where dropdown modal content would extend beyond the screen.